### PR TITLE
feat: Shopping cart screen

### DIFF
--- a/lib/screen/food_detail_screen.dart
+++ b/lib/screen/food_detail_screen.dart
@@ -117,13 +117,16 @@ class _FoodDetailScreenState extends State<FoodDetailScreen> {
                 child: Text("Choose up to 4 additional items."),
               ),
               ..._getContent(),
+              const SizedBox(
+                height: 130.0,
+              ),
             ],
           ),
         ),
 
         // Subtotal information fixed at bottom
         bottomSheet: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 5.0, horizontal: 15.0),
+          padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 15.0),
           child: SizedBox(
             height: 100.0,
             child: ListView(children: [
@@ -184,7 +187,7 @@ class _FoodDetailScreenState extends State<FoodDetailScreen> {
                         ),
                       )),
                   const SizedBox(
-                    width: 10.0,
+                    width: 15.0,
                   ),
                   Expanded(
                     flex: 6,

--- a/lib/screen/food_detail_screen.dart
+++ b/lib/screen/food_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:food_truck_mobile/widget/addition_food.dart';
+import 'package:food_truck_mobile/widget/button.dart';
 import 'package:food_truck_mobile/widget/text.dart';
 
 import '../helper/constants.dart';
@@ -160,13 +161,13 @@ class _FoodDetailScreenState extends State<FoodDetailScreen> {
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
-                            GestureDetector(
-                              onTap: () {
+                            IconButton(
+                              onPressed: () {
                                 setState(() {
                                   count = count > 1 ? count - 1 : 1;
                                 });
                               },
-                              child: Icon(
+                              icon: Icon(
                                 Icons.remove,
                                 color: removeColor,
                               ),
@@ -175,13 +176,15 @@ class _FoodDetailScreenState extends State<FoodDetailScreen> {
                               count.toString(),
                               style: const TextStyle(fontSize: 20),
                             ),
-                            GestureDetector(
-                              onTap: () {
+                            IconButton(
+                              onPressed: () {
                                 setState(() {
                                   count += 1;
                                 });
                               },
-                              child: const Icon(Icons.add),
+                              icon: const Icon(
+                                Icons.add,
+                              ),
                             ),
                           ],
                         ),
@@ -190,24 +193,16 @@ class _FoodDetailScreenState extends State<FoodDetailScreen> {
                     width: 15.0,
                   ),
                   Expanded(
-                    flex: 6,
-                    child: Container(
-                        height: 50.0,
-                        decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(8.0),
-                            color: Constants.primaryColor),
-                        child: const Center(
-                          child: TextTitleMedium(
-                            text: "Add to Order",
-                            color: Colors.white,
-                          ),
-                        )),
-                  )
+                      flex: 6,
+                      child: Button(
+                        text: "Add to Order",
+                        textColor: Colors.white,
+                        backgroundColor: Constants.primaryColor,
+                        takeLeastSpace: true,
+                        onPressed: () {},
+                      ))
                 ],
               ),
-              const SizedBox(
-                height: 10.0,
-              )
             ]),
           ),
         ));

--- a/lib/screen/restaurant_menu_screen.dart
+++ b/lib/screen/restaurant_menu_screen.dart
@@ -8,6 +8,7 @@ import 'package:food_truck_mobile/widget/section_header_tb.dart';
 import 'package:food_truck_mobile/widget/text.dart';
 
 import '../helper/constants.dart';
+import '../widget/button.dart';
 
 /// The [RestaurantMenuScreen], the parameter should be future changes to a
 /// Restaurant Model
@@ -88,7 +89,7 @@ class RestaurantMenuScreen extends StatelessWidget {
                       );
                     },
                     child: Container(
-                        height: 50.0,
+                        height: 45.0,
                         decoration: BoxDecoration(
                             border: Border.all(color: Constants.primaryColor),
                             borderRadius: BorderRadius.circular(8.0),
@@ -104,19 +105,14 @@ class RestaurantMenuScreen extends StatelessWidget {
                 width: 15.0,
               ),
               Expanded(
-                flex: 5,
-                child: Container(
-                    height: 50.0,
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(8.0),
-                        color: Constants.primaryColor),
-                    child: const Center(
-                      child: TextTitleMedium(
-                        text: "Checkout",
-                        color: Colors.white,
-                      ),
-                    )),
-              )
+                  flex: 5,
+                  child: Button(
+                    text: "Checkout",
+                    textColor: Colors.white,
+                    backgroundColor: Constants.primaryColor,
+                    takeLeastSpace: true,
+                    onPressed: () {},
+                  ))
             ],
           ),
         ),

--- a/lib/screen/restaurant_menu_screen.dart
+++ b/lib/screen/restaurant_menu_screen.dart
@@ -1,10 +1,13 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:food_truck_mobile/screen/shopping_cart_screen.dart';
 import 'package:food_truck_mobile/widget/food_button.dart';
 import 'package:food_truck_mobile/widget/section_divider.dart';
 import 'package:food_truck_mobile/widget/section_header_tb.dart';
 import 'package:food_truck_mobile/widget/text.dart';
+
+import '../helper/constants.dart';
 
 /// The [RestaurantMenuScreen], the parameter should be future changes to a
 /// Restaurant Model
@@ -55,25 +58,67 @@ class RestaurantMenuScreen extends StatelessWidget {
               isBold: true,
               padding: const EdgeInsets.symmetric(vertical: 15),
             ),
-
             TextTitleSmall(
               text: restaurantDescription,
               padding: EdgeInsets.zero,
             ),
-
             const SectionHeaderTB(text: 'Uncategorized'),
             ..._getContent(),
-            const SizedBox(height: 16),
-            Align(
-              alignment: Alignment.center,
-              child: ElevatedButton(
-                onPressed: () {
-                  // Complete order functionality
-                },
-                child: const Text('Complete Order'),
-              ),
-            ),
+            const SizedBox(height: 90.0),
           ],
+        ),
+      ),
+      bottomSheet: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 15.0),
+        child: SizedBox(
+          height: 60.0,
+          child: Row(
+            children: [
+              Expanded(
+                  flex: 5,
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        PageRouteBuilder(
+                          pageBuilder:
+                              (context, animation, secondaryAnimation) =>
+                                  const ShoppingCart(),
+                          transitionDuration: Duration.zero,
+                        ),
+                      );
+                    },
+                    child: Container(
+                        height: 50.0,
+                        decoration: BoxDecoration(
+                            border: Border.all(color: Constants.primaryColor),
+                            borderRadius: BorderRadius.circular(8.0),
+                            color: Colors.transparent),
+                        child: const Center(
+                          child: TextTitleMedium(
+                            text: "Shopping cart",
+                            color: Constants.primaryColor,
+                          ),
+                        )),
+                  )),
+              const SizedBox(
+                width: 15.0,
+              ),
+              Expanded(
+                flex: 5,
+                child: Container(
+                    height: 50.0,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8.0),
+                        color: Constants.primaryColor),
+                    child: const Center(
+                      child: TextTitleMedium(
+                        text: "Checkout",
+                        color: Colors.white,
+                      ),
+                    )),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screen/shopping_cart_screen.dart
+++ b/lib/screen/shopping_cart_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:food_truck_mobile/widget/cart_item.dart';
+import 'package:food_truck_mobile/widget/section_divider.dart';
+import 'package:food_truck_mobile/widget/text.dart';
+
+import '../helper/constants.dart';
+
+class ShoppingCart extends StatelessWidget {
+  final List<List> cartItems;
+
+  // cartItems should be passed in, this is only for UI purposes
+  const ShoppingCart(
+      {Key? key,
+      this.cartItems = const [
+        ["Artichoke Sandwich", 7.50, 2],
+        ["Egg Sandwich", 5.70, 1]
+      ]})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text("Shopping cart"),
+        ),
+        body: Padding(
+            padding:
+                const EdgeInsets.symmetric(vertical: 5.0, horizontal: 15.0),
+            child: ListView(
+              children: [
+                const TextTitleLarge(
+                  text: "Shopping cart",
+                  isBold: true,
+                ),
+                const SectionDivider(),
+                ..._getContent(),
+                const Row(
+                  children: [
+                    Expanded(
+                        child: TextTitleMedium(
+                      text: "Subtotal",
+                    )),
+                    TextTitleMedium(
+                      text: '\$ 7.50',
+                      padding: EdgeInsets.zero,
+                    )
+                  ],
+                ),
+                const Row(
+                  children: [
+                    Expanded(
+                        child: TextTitleMedium(
+                      text: "Delivery costs",
+                    )),
+                    TextTitleMedium(
+                      text: '\$ 3.26',
+                      padding: EdgeInsets.zero,
+                    )
+                  ],
+                ),
+                const Row(
+                  children: [
+                    Expanded(
+                        child: TextTitleMedium(
+                      text: "Total",
+                      isBold: true,
+                    )),
+                    TextTitleMedium(
+                      text: '\$ 10.26',
+                      padding: EdgeInsets.zero,
+                      isBold: true,
+                    )
+                  ],
+                ),
+                const SizedBox(
+                  height: 90.0,
+                )
+              ],
+            )),
+        bottomSheet: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 15.0),
+          child: SizedBox(
+            height: 60.0,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Container(
+                      height: 50.0,
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(8.0),
+                          color: Constants.primaryColor),
+                      child: const Center(
+                        child: TextTitleMedium(
+                          text: "Checkout",
+                          color: Colors.white,
+                        ),
+                      )),
+                )
+              ],
+            ),
+          ),
+        ));
+  }
+
+  List<Widget> _getContent() {
+    List<Widget> content = [];
+    for (var element in cartItems) {
+      content.add(CartItem(
+        itemName: element[0],
+        itemPrice: element[1],
+        count: element[2],
+      ));
+    }
+
+    return content;
+  }
+}

--- a/lib/screen/shopping_cart_screen.dart
+++ b/lib/screen/shopping_cart_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:food_truck_mobile/widget/button.dart';
 import 'package:food_truck_mobile/widget/cart_item.dart';
+import 'package:food_truck_mobile/widget/checkout_item.dart';
 import 'package:food_truck_mobile/widget/section_divider.dart';
 import 'package:food_truck_mobile/widget/text.dart';
 
@@ -34,43 +36,12 @@ class ShoppingCart extends StatelessWidget {
                 ),
                 const SectionDivider(),
                 ..._getContent(),
-                const Row(
-                  children: [
-                    Expanded(
-                        child: TextTitleMedium(
-                      text: "Subtotal",
-                    )),
-                    TextTitleMedium(
-                      text: '\$ 7.50',
-                      padding: EdgeInsets.zero,
-                    )
-                  ],
-                ),
-                const Row(
-                  children: [
-                    Expanded(
-                        child: TextTitleMedium(
-                      text: "Delivery costs",
-                    )),
-                    TextTitleMedium(
-                      text: '\$ 3.26',
-                      padding: EdgeInsets.zero,
-                    )
-                  ],
-                ),
-                const Row(
-                  children: [
-                    Expanded(
-                        child: TextTitleMedium(
-                      text: "Total",
-                      isBold: true,
-                    )),
-                    TextTitleMedium(
-                      text: '\$ 10.26',
-                      padding: EdgeInsets.zero,
-                      isBold: true,
-                    )
-                  ],
+                const CheckoutItem(name: "Subtotal", price: 7.50),
+                const CheckoutItem(name: "Delivery costs", price: 3.26),
+                const CheckoutItem(
+                  name: "Total",
+                  price: 10.26,
+                  isBold: true,
                 ),
                 const SizedBox(
                   height: 90.0,
@@ -84,18 +55,13 @@ class ShoppingCart extends StatelessWidget {
             child: Row(
               children: [
                 Expanded(
-                  child: Container(
-                      height: 50.0,
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(8.0),
-                          color: Constants.primaryColor),
-                      child: const Center(
-                        child: TextTitleMedium(
-                          text: "Checkout",
-                          color: Colors.white,
-                        ),
-                      )),
-                )
+                    child: Button(
+                  text: "Checkout",
+                  textColor: Colors.white,
+                  backgroundColor: Constants.primaryColor,
+                  takeLeastSpace: true,
+                  onPressed: () {},
+                ))
               ],
             ),
           ),

--- a/lib/widget/cart_item.dart
+++ b/lib/widget/cart_item.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:food_truck_mobile/widget/section_divider.dart';
+import 'package:food_truck_mobile/widget/text.dart';
+
+class CartItem extends StatefulWidget {
+  final String itemName;
+  final double itemPrice;
+  final int count;
+
+  const CartItem(
+      {Key? key,
+      required this.itemName,
+      required this.itemPrice,
+      required this.count})
+      : super(key: key);
+
+  @override
+  State<CartItem> createState() => _CartItemState();
+}
+
+class _CartItemState extends State<CartItem> {
+  int count = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    count = widget.count;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Color removeColor = count == 1 ? Colors.grey : Colors.black;
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+                child: TextTitleMedium(
+              text: widget.itemName,
+              isBold: true,
+            )),
+            TextTitleMedium(
+              text: '\$ ${widget.itemPrice.toStringAsFixed(2)}',
+              padding: EdgeInsets.zero,
+            ),
+          ],
+        ),
+        const SizedBox(
+          height: 20.0,
+        ),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            const Expanded(child: TextTitleMedium(text: "Quantity")),
+            Container(
+              height: 50.0,
+              width: 120.0,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        count = count > 1 ? count - 1 : 1;
+                      });
+                    },
+                    child: Icon(
+                      Icons.remove,
+                      color: removeColor,
+                    ),
+                  ),
+                  Text(
+                    count.toString(),
+                    style: const TextStyle(fontSize: 20),
+                  ),
+                  GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        count += 1;
+                      });
+                    },
+                    child: const Icon(Icons.add),
+                  ),
+                ],
+              ),
+            )
+          ],
+        ),
+        const SectionDivider()
+      ],
+    );
+  }
+}

--- a/lib/widget/cart_item.dart
+++ b/lib/widget/cart_item.dart
@@ -63,13 +63,13 @@ class _CartItemState extends State<CartItem> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
-                  GestureDetector(
-                    onTap: () {
+                  IconButton(
+                    onPressed: () {
                       setState(() {
                         count = count > 1 ? count - 1 : 1;
                       });
                     },
-                    child: Icon(
+                    icon: Icon(
                       Icons.remove,
                       color: removeColor,
                     ),
@@ -78,13 +78,15 @@ class _CartItemState extends State<CartItem> {
                     count.toString(),
                     style: const TextStyle(fontSize: 20),
                   ),
-                  GestureDetector(
-                    onTap: () {
+                  IconButton(
+                    onPressed: () {
                       setState(() {
                         count += 1;
                       });
                     },
-                    child: const Icon(Icons.add),
+                    icon: const Icon(
+                      Icons.add,
+                    ),
                   ),
                 ],
               ),

--- a/lib/widget/checkout_item.dart
+++ b/lib/widget/checkout_item.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:food_truck_mobile/widget/text.dart';
+
+class CheckoutItem extends StatelessWidget {
+  final String name;
+  final double price;
+  final bool isBold;
+
+  const CheckoutItem(
+      {Key? key, required this.name, required this.price, this.isBold = false})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+            child: TextTitleMedium(
+          text: name,
+          isBold: isBold,
+        )),
+        TextTitleMedium(
+          text: '\$ ${price.toStringAsFixed(2)}',
+          padding: EdgeInsets.zero,
+          isBold: isBold,
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### Description

- Add the bottom sheet for the restaurant menu screen, including two buttons
  - Shopping cart
  - Checkout

- Implement a shopping cart screen
  - All hardcoded including the cart items info and the subtotal/total
  - The counter is interactive

### TODO
1. Dynamically render cart items, including amount, price, etc.
2. Refactor the counter, it appears in both food details screen and shopping cart screen

### Note

Originally, this PR was composed of 3 commits. For the clarity of the git log, three commits were squashed into one. Tell me you like it or not
